### PR TITLE
Remove special handling for age links

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,8 +7,7 @@
 }
 
 tbody.points .subtext .score,
-tbody.age .subtext.age, /* job posting */
-tbody.age .subtext .age,
+tbody.age .subtext span.age a,
 tbody.comments .subtext .comments {
     color: red;
 }

--- a/js/background.js
+++ b/js/background.js
@@ -1,0 +1,5 @@
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+    if (message.type === 'showPageAction') {
+        chrome.pageAction.show(sender.tab.id);
+    }
+});

--- a/js/components/sort_controls.js
+++ b/js/components/sort_controls.js
@@ -30,6 +30,6 @@ var SortControls = (function() {
         });
     }
 
-    return flight.component(sortControls);
+    return flight.component(sortControls, withPageActions);
 
 })();

--- a/js/components/stories.js
+++ b/js/components/stories.js
@@ -53,9 +53,7 @@ var Stories = (function() {
             "articles": "tr.athing",
             "articlesTableBody": "tbody:first",
             "lastArticle": "tr.spacer:last",
-            "ageLinks": ".subtext a:contains(' ago')",
-            "commentLinks": ".subtext a:contains('comment')",
-            "jobPostingSubtext": ".subtext:not(:has(a))"
+            "commentLinks": ".subtext a:contains('comment')"
         });
    
         // returns an array of "story" meta-objects
@@ -70,8 +68,6 @@ var Stories = (function() {
 
         this.setupArticlesTable = function() {
             this.$node.addClass("articles");
-            this.select("ageLinks").addClass("age");
-            this.select("jobPostingSubtext").addClass("age");
             this.select("commentLinks").addClass("comments");
         };
 

--- a/js/mixins/withPageActions.js
+++ b/js/mixins/withPageActions.js
@@ -1,0 +1,10 @@
+function withPageActions() {
+
+    this.showPageAction = function() {
+        chrome.runtime.sendMessage({type:'showPageAction'});
+    };
+
+    this.after('initialize', function() {
+        this.showPageAction();
+    });
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Sort Hacker News",
   "short_name": "hnsort",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "manifest_version": 2,
   "description": "Sort stories on Hacker News",
   "homepage_url": "http://wayneburkett.com",
@@ -13,6 +13,14 @@
   "default_locale": "en",
   "permissions": [
   ],
+  "page_action": {
+  },
+  "background": {
+    "scripts": [
+      "js/background.js"
+    ],
+    "persistent": true
+  },
   "content_scripts": [
     {
       "run_at": "document_end",
@@ -42,6 +50,7 @@
         "js/lib/jquery-2.1.4.min.js",
         "js/lib/mustache.min.js",
         "js/lib/flight.min.js",
+        "js/mixins/withPageActions.js",
         "js/components/stories.js",
         "js/components/sort_controls.js",
         "js/inject.js"


### PR DESCRIPTION
HN added an "age" class to the parent span at some point over the last
two years, so there's no need for special handling here.